### PR TITLE
NCP 업로드 API 작성

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -21,5 +21,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
   },
 };

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "@nestjs/swagger": "^7.1.15",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "dotenv": "^16.3.1",
     "mongoose": "^8.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { putObject } from './ncpAPI/putObject';
 
 @Controller()
 export class AppController {
@@ -8,5 +9,35 @@ export class AppController {
   @Get('ads')
   getAds() {
     return this.appService.getAds();
+  }
+  @Get('test')
+  test() {
+    return requestEncoding(process.env.INPUT_BUCKET, ['lplbisang.mp4'])
+      .then(function (response) {
+        return response.data;
+      })
+      .catch(function (error) {
+        if (error.response) {
+          return error.response.data;
+        }
+        return error;
+      });
+  }
+  @Get('test2')
+  test2() {
+    return putObject(
+      'video-thimbnail-bucket',
+      'sample-object.txt',
+      'hellohello',
+    )
+      .then(function (response) {
+        return response.data;
+      })
+      .catch(function (error) {
+        if (error.response) {
+          return error.response.data;
+        }
+        return error;
+      });
   }
 }

--- a/server/src/ncpAPI/common.ts
+++ b/server/src/ncpAPI/common.ts
@@ -1,0 +1,127 @@
+import * as CryptoJS from 'crypto-js';
+
+export function makeSignature(method: string, url: string, timestamp: number) {
+  const space = ' '; // one space
+  const newLine = '\n'; // new line
+  const accessKey = process.env.ACCESS_KEY!;
+  const secretKey = process.env.SECRET_KEY!;
+
+  const hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, secretKey);
+  hmac.update(method);
+  hmac.update(space);
+  hmac.update(url);
+  hmac.update(newLine);
+  hmac.update(`${timestamp}`);
+  hmac.update(newLine);
+  hmac.update(accessKey);
+
+  const hash = hmac.finalize();
+
+  return hash.toString(CryptoJS.enc.Base64);
+}
+
+export const getAuthorization = (headers: object): string => {
+  const accessKeyID = process.env.ACCESS_KEY!;
+  const region = 'kr-standard';
+
+  const date = getDateStamp();
+
+  const scope = `${date}/${region}/s3/aws4_request`;
+
+  const signedHeaders = Object.keys(headers).join(';');
+
+  const kSignature = createSignatureKey(scope, headers);
+  const authorization = `AWS4-HMAC-SHA256 Credential=${accessKeyID}/${scope}, SignedHeaders=${signedHeaders}, Signature=${kSignature}`;
+  return authorization;
+};
+
+const createSignatureKey = (scope: string, headers: object): string => {
+  const kSigning = createSigningKey();
+  const stringToSign = createStringToSign(scope, headers);
+  const kSignature = CryptoJS.HmacSHA256(stringToSign, kSigning).toString(
+    CryptoJS.enc.Hex,
+  );
+  return kSignature;
+};
+
+const createSigningKey = () => {
+  const region = 'kr-standard';
+  const kSecret = process.env.SECRET_KEY!;
+
+  const kDate = getHash('AWS4' + kSecret, getDateStamp());
+  const kRegion = getHash(kDate, region);
+  const kService = getHash(kRegion, 's3');
+  const kSigning = getHash(kService, 'aws4_request');
+
+  return kSigning;
+};
+
+const getHash = (key: any, message: string) => {
+  console.log(key);
+  console.log(message);
+  return CryptoJS.HmacSHA256(message, key);
+  // return crypto.createHmac('sha256', key).update(message).digest();
+};
+
+const createStringToSign = (scope: string, headers: object) => {
+  const timeStamp = getTimeStamp();
+  const method = 'PUT';
+  const canonicalURI = '/video-thimbnail-bucket/sample-object.txt';
+  const canonicalRequest = createCanonicalRequest(
+    method,
+    canonicalURI,
+    headers,
+  );
+
+  const stringToSign = `AWS4-HMAC-SHA256
+${timeStamp}
+${scope}
+${CryptoJS.enc.Hex.stringify(CryptoJS.SHA256(canonicalRequest))}`;
+
+  return stringToSign;
+};
+
+const createCanonicalRequest = (
+  method: string,
+  path: string,
+  headers: object,
+) => {
+  const hashedPayLoad = 'UNSIGNED-PAYLOAD';
+  const { canonicalHeaders, signedHeaders } = getHeaders(headers);
+  const canonicalRequest = `${method}
+${path}
+
+${canonicalHeaders}
+
+${signedHeaders}
+${hashedPayLoad}`;
+  console.log(`canonicalRequest : ${canonicalRequest}`);
+  return canonicalRequest;
+};
+
+const getHeaders = (headers: object) => {
+  const canonicalHeaders = Object.entries(headers)
+    .map(([key, value]) => `${key}:${value}`)
+    .join('\n');
+  const signedHeaders = Object.keys(headers).join(';');
+  return { canonicalHeaders, signedHeaders };
+};
+
+const getDateStamp = (): string => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1; // 한자리 수 예외 처리 필요
+  const day = today.getDate();
+
+  const date = `${year}${month}${day}`;
+  return date;
+};
+
+export const getTimeStamp = (): string => {
+  const today = new Date();
+  const timeStamp = today
+    .toISOString()
+    .replace(/[:-]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z'); // by GPT
+  return timeStamp;
+};

--- a/server/src/ncpAPI/putObject.ts
+++ b/server/src/ncpAPI/putObject.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { getTimeStamp, getAuthorization } from './common';
+
+export const putObject = (bucketName: string, objectName: string, data) => {
+  const endPoint = 'https://kr.object.ncloudstorage.com';
+  const apiUrl = `${endPoint}/${bucketName}/${objectName}`;
+
+  const timeStamp = getTimeStamp();
+  const defaultHeaders = {
+    host: 'kr.object.ncloudstorage.com',
+    'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',
+    'x-amz-date': timeStamp,
+  };
+
+  return axios.put(apiUrl, data, {
+    headers: {
+      Authorization: getAuthorization(defaultHeaders),
+      ...defaultHeaders,
+    },
+  });
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2144,7 +2144,7 @@ dotenv-expand@10.0.0:
   resolved "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
-dotenv@16.3.1:
+dotenv@16.3.1, dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==


### PR DESCRIPTION
related To: #26

# 작업 내용
- NCP의 Object Storage에 object를 업로드하는 api를 작성했습니다.
  - Object Storage API의 공통 인증 헤더 내용이 포함돼 있습니다.

# 전달 사항
- ncp에 api 요청을 보냈을 때 지속적으로 `403` 응답을 받았는데, 민석님 도움으로 같이 해결할 수 있었습니다!
  - signature key 문자열을 생성할 때 개행이 들어가 있었던 문제
  - axios로 put 요청을 보낼 때 data의 위치 문제
