### PR TITLE
랜덤 비디오 응답

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -31,13 +31,16 @@ export class AuthService {
     if (await this.UserModel.findOne({ uuid })) {
       throw new UserConflictException();
     }
-    const extension = profileImage.originalname.split('.').pop();
+    const profileImageExtension = profileImage.originalname.split('.').pop();
     putObject(
       process.env.PROFILE_BUCKET,
-      `${uuid}.${extension}`,
+      `${uuid}.${profileImageExtension}`,
       profileImage.buffer,
     );
-    const newUser = new this.UserModel(signupRequestDto);
+    const newUser = new this.UserModel({
+      ...signupRequestDto,
+      profileImageExtension,
+    });
     newUser.save();
     const jwt = await this.getTokens(uuid);
     const profile = new ProfileResponseDto({

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -23,6 +23,9 @@ async function bootstrap() {
     new ValidationPipe({
       whitelist: true, // DTO에 정의되지 않은 속성 제거
       transform: true, // 타입 자동 변환
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
     }),
   );
   app.useGlobalInterceptors(new TransformInterceptor());

--- a/server/src/ncpAPI/getObject.ts
+++ b/server/src/ncpAPI/getObject.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getTimeStamp, getAuthorization } from './common';
 
-export const getObject = (bucketName: string, objectName: string) => {
+export const getObject = async (bucketName: string, objectName: string) => {
   const endPoint = 'https://kr.object.ncloudstorage.com';
   const canonicalURI = `/${bucketName}/${objectName}`;
   const apiUrl = `${endPoint}${canonicalURI}`;
@@ -14,7 +14,7 @@ export const getObject = (bucketName: string, objectName: string) => {
   };
 
   const method = 'GET';
-  return axios.get(apiUrl, {
+  const response = await axios.get(apiUrl, {
     headers: {
       Authorization: getAuthorization(
         method,
@@ -25,4 +25,5 @@ export const getObject = (bucketName: string, objectName: string) => {
       ...defaultHeaders,
     },
   });
+  return response.data;
 };

--- a/server/src/user/schemas/user.schema.ts
+++ b/server/src/user/schemas/user.schema.ts
@@ -15,15 +15,14 @@ export class User {
   @Prop({ type: [{ type: ActionSchema }] })
   actions: Action[];
 
-  @Prop({
-    require: true,
-  })
+  @Prop({ require: true })
   nickname: string;
 
-  @Prop({
-    require: true,
-  })
+  @Prop({ require: true })
   statusMessage: string;
+
+  @Prop()
+  profileImageExtension: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/server/src/video/dto/random-video-query.dto.ts
+++ b/server/src/video/dto/random-video-query.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsInt, IsPositive } from 'class-validator';
+import { CategoryEnum } from '../enum/category.enum';
+
+export class RandomVideoQueryDto {
+  /**
+   * 요청하는 비디오 수
+   */
+  @IsInt()
+  @IsPositive()
+  limit: number;
+
+  /**
+   * 비디오 카테고리
+   * @example '챌린지'
+   */
+  @IsEnum(CategoryEnum)
+  category: CategoryEnum;
+}

--- a/server/src/video/video.controller.ts
+++ b/server/src/video/video.controller.ts
@@ -23,6 +23,7 @@ import { VideoService } from './video.service';
 import { VideoDto } from './dto/video.dto';
 import { VideoRatingDTO } from './dto/video-rating.dto';
 import { FileExtensionPipe } from './video.pipe';
+import { RandomVideoQueryDto } from './dto/random-video-query.dto';
 
 @UseGuards(AuthGuard)
 @ApiBearerAuth()
@@ -34,11 +35,8 @@ export class VideoController {
   ) {}
 
   @Get('random')
-  getRandomVideo(
-    @Query('category') category: string,
-    @Query('limit') limit: number,
-  ) {
-    return this.videoService.getRandomVideo(category, limit);
+  getRandomVideo(@Query() query: RandomVideoQueryDto) {
+    return this.videoService.getRandomVideo(query.category, query.limit);
   }
 
   @Put(':id/rating')

--- a/server/src/video/video.controller.ts
+++ b/server/src/video/video.controller.ts
@@ -12,6 +12,7 @@ import {
   UploadedFiles,
   UseGuards,
   Request,
+  Query,
 } from '@nestjs/common';
 import { createReadStream } from 'fs';
 import { join } from 'path';
@@ -23,6 +24,8 @@ import { VideoDto } from './dto/video.dto';
 import { VideoRatingDTO } from './dto/video-rating.dto';
 import { FileExtensionPipe } from './video.pipe';
 
+@UseGuards(AuthGuard)
+@ApiBearerAuth()
 @Controller('videos')
 export class VideoController {
   constructor(
@@ -32,8 +35,8 @@ export class VideoController {
 
   @Get('random')
   getRandomVideo(
-    @Param('category') category: string,
-    @Param('limit') limit: number,
+    @Query('category') category: string,
+    @Query('limit') limit: number,
   ) {
     return this.videoService.getRandomVideo(category, limit);
   }
@@ -61,8 +64,6 @@ export class VideoController {
       { name: 'thumbnail', maxCount: 1 },
     ]),
   )
-  @UseGuards(AuthGuard)
-  @ApiBearerAuth()
   @Post()
   uploadVideo(
     @UploadedFiles() files: Array<Express.Multer.File>,

--- a/server/src/video/video.service.ts
+++ b/server/src/video/video.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable class-methods-use-this */
 import { Injectable } from '@nestjs/common';
@@ -17,8 +18,19 @@ export class VideoService {
     @InjectModel('User') private UserModel: Model<User>,
   ) {}
 
-  getRandomVideo(category: string, limit: number) {
-    return `get random video ${category} ${limit}`;
+  async getRandomVideo(category: string, limit: number) {
+    const videos = await this.VideoModel.aggregate([
+      { $match: { category } },
+      { $sample: { size: limit } },
+    ]);
+    const videoData = videos.map((video) => {
+      const { totalRating, raterCount, _id, __v, ...videoInfo } = video;
+      const rating = totalRating / raterCount.toFixed(1);
+      return {
+        video: { ...videoInfo, rating },
+      };
+    });
+    return videoData;
   }
 
   updateVideoRating(videoId: string, videoRatingDto: VideoRatingDTO) {


### PR DESCRIPTION
resolved: #71

# 작업 내용
- client가 랜덤 비디오 n개 요청 시 비디오 정보, 업로드 한 유저 정보 반환

# 전달 사항
- 업로드한 유저 프로필 이미지를 NCP에서 다운로드 하는 것은 오래 걸리지 않는데, client에게 응답 시 JSON data 내에 이미지 데이터 내용을 직접 담아서 보내면 조금 느린 경향이 있습니다! 테스트 이후 느리다고 판단되면 논의가 필요할 것 같습니다.
- user schema에 프로필 이미지 확장자를 추가하였습니다.

## 참조
[MongoDB populate](https://stackoverflow.com/questions/16680015/how-to-use-populate-and-aggregate-in-same-statement)