### PR TITLE
랜덤 비디오 응답 시 중복 제거

### DIFF
--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -81,6 +81,7 @@ export class UserController {
    * 특정 유저가 별점을 준 비디오 정보 반환
    */
   @Get(':userId/videos/rated')
+  @ApiTags('COMPLETE')
   @ApiSuccessResponse(200, '비디오 반환 성공', RatedVideoResponseDto)
   @ApiFailResponse('존재하지 않는 user', [UserNotFoundException])
   getRatedVideos(

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -128,7 +128,7 @@ export class UserService {
     const videos = await Promise.all(
       videoData.map(async (video) => {
         const { thumbnailExtension, ...videoInfo } = video.toObject();
-        const manifest = `${process.env.MANIFEST_URL_PREFIX}${videoInfo._id}_,${process.env.ENCODING_SUFFIXES}${process.env.ABR_MANIFEST_URL_SUFFIX}`;
+        const manifest = `${process.env.SERVER_URL}videos/${videoInfo._id}/manifest`;
         const thumbnailImage = await getBucketImage(
           process.env.THUMBNAIL_BUCKET,
           thumbnailExtension,

--- a/server/src/video/dto/random-video-query.dto.ts
+++ b/server/src/video/dto/random-video-query.dto.ts
@@ -22,6 +22,10 @@ export class RandomVideoQueryDto {
   @IsEnum(CategoryEnum)
   category: CategoryEnum;
 
+  /**
+   * 해당 시드로 시청된 영상은 제외하여 응답
+   * @example 123456
+   */
   @IsOptional()
   @IsNumber()
   seed?: number;

--- a/server/src/video/dto/random-video-query.dto.ts
+++ b/server/src/video/dto/random-video-query.dto.ts
@@ -1,4 +1,10 @@
-import { IsEnum, IsInt, IsPositive } from 'class-validator';
+import {
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+} from 'class-validator';
 import { CategoryEnum } from '../enum/category.enum';
 
 export class RandomVideoQueryDto {
@@ -15,4 +21,8 @@ export class RandomVideoQueryDto {
    */
   @IsEnum(CategoryEnum)
   category: CategoryEnum;
+
+  @IsOptional()
+  @IsNumber()
+  seed?: number;
 }

--- a/server/src/video/dto/random-video-response.dto.ts
+++ b/server/src/video/dto/random-video-response.dto.ts
@@ -1,0 +1,8 @@
+import { VideoListResponseDto } from './video-list-response.dto';
+
+export class RandomVideoResponseDto extends VideoListResponseDto {
+  /**
+   * @example https://server_ip/videos/random?limit=&category=&seed=
+   */
+  next: string;
+}

--- a/server/src/video/video.controller.ts
+++ b/server/src/video/video.controller.ts
@@ -42,6 +42,7 @@ import { VideoInfoDto } from './dto/video-info.dto';
 import { VideoRatingResponseDTO } from './dto/video-rating-response.dto';
 import { TopVideoQueryDto } from './dto/top-video-query.dto';
 import { VideoListResponseDto } from './dto/video-list-response.dto';
+import { RandomVideoResponseDto } from './dto/random-video-response.dto';
 
 @ApiBearerAuth()
 @UseGuards(AuthGuard)
@@ -59,7 +60,7 @@ export class VideoController {
    */
   @ApiTags('COMPLETE')
   @Get('random')
-  @ApiSuccessResponse(200, '랜덤 비디오 반환 성공', VideoListResponseDto)
+  @ApiSuccessResponse(200, '랜덤 비디오 반환 성공', RandomVideoResponseDto)
   getRandomVideo(
     @Query() query: RandomVideoQueryDto,
     @RequestUser() user: User,

--- a/server/src/video/video.controller.ts
+++ b/server/src/video/video.controller.ts
@@ -60,8 +60,11 @@ export class VideoController {
   @ApiTags('COMPLETE')
   @Get('random')
   @ApiSuccessResponse(200, '랜덤 비디오 반환 성공', VideoListResponseDto)
-  getRandomVideo(@Query() query: RandomVideoQueryDto) {
-    return this.videoService.getRandomVideo(query.category, query.limit);
+  getRandomVideo(
+    @Query() query: RandomVideoQueryDto,
+    @RequestUser() user: User,
+  ) {
+    return this.videoService.getRandomVideo(query, user.id);
   }
 
   /**

--- a/server/src/video/video.controller.ts
+++ b/server/src/video/video.controller.ts
@@ -104,6 +104,7 @@ export class VideoController {
    * Manifest 파일 반환
    */
   @IgnoreInterceptor()
+  @ApiTags('COMPLETE')
   @Get(':id/manifest')
   @ApiProduces('application/vnd.apple.mpegurl')
   @ApiOkResponse({
@@ -128,6 +129,7 @@ export class VideoController {
    * 인기 비디오 반환
    */
   @Get('trend')
+  @ApiTags('COMPLETE')
   @ApiSuccessResponse(200, '비디오 조회 성공', VideoListResponseDto)
   getTrendVideo(@Query('limit') limit: number) {
     return this.videoService.getTrendVideo(limit);

--- a/server/src/video/video.service.ts
+++ b/server/src/video/video.service.ts
@@ -96,14 +96,7 @@ export class VideoService {
     const videoInfos = await Promise.all(
       videos.map((video) => this.getVideoInfo(video, viewSeed)),
     );
-    const nextQueryString = new URLSearchParams({
-      category,
-      limit,
-      seed: viewSeed,
-    } as any).toString();
-
-    const next = `${process.env.SERVER_URL}videos/random?${nextQueryString}`;
-    return { videos: videoInfos, next };
+    return { videos: videoInfos, seed: viewSeed };
   }
 
   async getManifest(videoId: string, userId: string, seed: number) {


### PR DESCRIPTION
resolved: #130 

# 작업 내용
- Manifest 응답 서버 URL로 수정
- 랜덤 비디오 응답 시 중복 영상 제거

# 전달 사항 
- 중복 제거 로직
  1. 랜덤 비디오 응답으로 받은 비디오 URL에는 동일한 seed값이 쿼리스트링으로 들어가있습니다 
  2. 비디오 URL 요청시 쿼리로 받은 seed 값으로 영상을 시청했다고 기록합니다. 
  3. 랜덤 비디오 응답에서는 한번도 시청하지 않은 영상을 최우선순위로 하여 limit개 만큼 샘플링 시도 합니다
  4. limit개 만큼 뽑지 못했으면 시청한 영상들중 동일한 seed값으로 시청되지 않은 영상 중에서 부족한만큼 샘플링 합니다.