### PR TITLE
랜덤 비디오 응답 및 별점 준 비디오 응답 버그 수정

### DIFF
--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -178,15 +178,22 @@ export class UserService {
     limit: number,
     lastRatedAt: string,
   ): Promise<RatedVideoResponseDto> {
-    const array = lastRatedAt
+    const condition = lastRatedAt
       ? {
-          $filter: {
-            input: '$actions',
-            as: 'action',
-            cond: { $lt: ['$$action.updatedAt', new Date(lastRatedAt)] },
-          },
+          $and: [
+            { $lt: ['$$action.updatedAt', new Date(lastRatedAt)] },
+            { $ne: ['$$action.rating', null] },
+          ],
         }
-      : '$actions';
+      : { $ne: ['$$action.rating', null] };
+
+    const array = {
+      $filter: {
+        input: '$actions',
+        as: 'action',
+        cond: condition,
+      },
+    };
 
     const data = await this.UserModel.aggregate([
       { $match: { uuid } },

--- a/server/src/video/video.service.ts
+++ b/server/src/video/video.service.ts
@@ -37,6 +37,7 @@ export class VideoService {
     { category, limit, seed }: RandomVideoQueryDto,
     userId: string,
   ) {
+    console.log('random video response:', category, limit, seed);
     const actions = await this.UserModel.aggregate([
       { $match: { uuid: userId } },
       { $unwind: '$actions' },
@@ -63,7 +64,9 @@ export class VideoService {
       { $replaceRoot: { newRoot: '$actions' } },
     ]);
 
-    const viewIdList = actions.map((userAction) => userAction.videoId);
+    const viewIdList = actions.map(
+      (userAction) => new Types.ObjectId(userAction.videoId),
+    );
     const condition = {
       _id: { $not: { $in: viewIdList } },
       ...(category !== CategoryEnum.전체 && { category }),
@@ -258,10 +261,7 @@ export class VideoService {
     if (!video) {
       throw new VideoNotFoundException();
     }
-    if (
-      uuid !== process.env.ADMIN_UUID &&
-      video.uploaderId.uuid !== uuid
-    ) {
+    if (uuid !== process.env.ADMIN_UUID && video.uploaderId.uuid !== uuid) {
       throw new NotYourVideoException();
     }
     await Promise.all([


### PR DESCRIPTION
resolved: #274 

# 작업 내용
- 별점 준 비디오 쿼리 시 rating이 null이 아닌 것만 filter하여 시청만 한 영상은 응답에서 제외 
- 랜덤 비디오 응답 시 시청한 비디오 id 리스트를 string이 아닌 objectId로 변경하여 시청하지 않은 영상 우선 응답

